### PR TITLE
feat: add the first web draft workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ go run ./cmd/skillforge draft submit draft01
 
 ## Web UI preview
 
-The first browser UI slice now lives under [`web/`](web/) and currently focuses on read-only catalog discovery. Browse mode now follows the paginated catalog API until it has the full skill list, so larger repositories are no longer silently truncated at the server's default first page.
+The browser UI now lives under [`web/`](web/) and supports both catalog discovery and the first browser-driven draft flow. Browse mode follows the paginated catalog API until it has the full skill list, and the current write slice can create/create update/delete drafts, inspect validation + submission readiness, and submit the current draft through the existing Go API.
 
 Run it locally next to the API with:
 

--- a/docs/dev-stack.md
+++ b/docs/dev-stack.md
@@ -90,7 +90,7 @@ A minimal local verification flow for draft-to-PR submission is:
 
 ## Web UI development
 
-The first browser UI lives in `web/` and is intentionally read-only in this slice.
+The browser UI lives in `web/` and now supports both read flows and the first browser draft-authoring path.
 
 Run it locally with:
 
@@ -101,6 +101,8 @@ npm run dev
 ```
 
 The Vite dev server proxies `/api/*` to `http://localhost:8080` by default. Set `VITE_API_BASE_URL` when the UI should talk to a different API origin or path prefix.
+
+For write-flow verification, point the UI at an API instance that has access to a writable managed working copy. Draft creation works against the current draft API; draft submission only succeeds when live submission is configured, otherwise the UI will surface the reported disabled-submission reason.
 
 ## Notes
 

--- a/openspec/changes/2026-03-29-web-ui-draft-write-slice/design.md
+++ b/openspec/changes/2026-03-29-web-ui-draft-write-slice/design.md
@@ -1,0 +1,72 @@
+# Design: web-ui-draft-write-slice
+
+## Summary
+
+Extend the current React web UI with a draft authoring panel backed by the existing Go draft lifecycle API. Keep the first write batch pragmatic: one panel for composing a create/update/delete draft, validation feedback after draft creation, and a submit action for the currently active draft.
+
+## Goals
+
+- ship the first write-capable browser workflow for Skillforge
+- reuse the existing draft API contract without broad backend redesign
+- expose validation and submission status honestly in the UI
+- keep the first write batch maintainable and easy to verify
+
+## Non-goals
+
+- authentication or user identity
+- reviewer/admin dashboards
+- concurrent multi-draft session management
+- rich Markdown editing or preview tooling
+- backend draft API redesign beyond narrow compatibility fixes
+
+## Architecture
+
+### Frontend API layer
+
+Extend `web/src/api.ts` with typed functions and payloads for:
+
+- `POST /api/v1/drafts`
+- `GET /api/v1/drafts/{id}`
+- `POST /api/v1/drafts/{id}/submit`
+
+Preserve the existing same-origin API behavior.
+
+### UI shape
+
+Keep the current two-panel browse/detail layout and add a draft authoring section in the detail panel.
+
+The authoring section will:
+
+- allow choosing `create`, `update`, or `delete`
+- allow editing the target skill name
+- allow editing draft content for create/update operations
+- disable content editing for delete operations
+- create a draft against the backend and render the returned validation and submission status
+- allow submitting the current created draft when submission is enabled
+- show explicit create/submit loading and error states
+
+### State model
+
+The first write slice uses local component state in `App.tsx` instead of introducing a new global state layer.
+
+Track:
+
+- draft form inputs (`operation`, `skillName`, `content`)
+- create-draft request state and error
+- current created draft record
+- submit request state, error, and success payload
+
+When a user selects a skill in browse mode, the form may prefill the skill name and current body for update-oriented workflows, but explicit user edits remain source of truth.
+
+## Verification strategy
+
+- `npm test` in `web/`
+- `npm run build` in `web/`
+- `npm run lint` in `web/`
+- `openspec validate 2026-03-29-web-ui-draft-write-slice --strict`
+
+## Risks and tradeoffs
+
+- keeping authoring state in `App.tsx` is simple for the first write batch, but may need extraction as the UI grows
+- surfacing only the current active draft keeps scope small, but does not yet provide a draft history view
+- the UI depends on the existing server-side draft contract, so any rough edges in error payloads will show up more clearly than they did in the CLI

--- a/openspec/changes/2026-03-29-web-ui-draft-write-slice/proposal.md
+++ b/openspec/changes/2026-03-29-web-ui-draft-write-slice/proposal.md
@@ -1,0 +1,28 @@
+# web-ui-draft-write-slice
+
+## Why
+
+Skillforge now has a proven backend draft lifecycle, a Go CLI for draft submission, and a first read-only web UI. The browser surface is still missing the most important remaining workflow from the project brief: create, update, and delete flows for skills.
+
+Without a write-capable browser path, the web UI is still only a demo surface for discovery. The next round should reuse the existing draft APIs to turn it into a real authoring surface for non-CLI users.
+
+## What Changes
+
+This change introduces the first write-capable web UI slice for Skillforge.
+
+It will:
+
+1. add a shared frontend API layer for draft create/status/submit flows
+2. add a draft authoring panel to the existing web UI
+3. support create, update, and delete draft operations from the browser
+4. surface validation findings and submission capability/status in the UI
+5. support submitting a created draft from the browser
+6. add targeted UI tests for representative authoring, validation, and submission states
+7. document the write-capable UI flow and its local-development expectations
+
+## Impact
+
+- turns the web UI into the first end-to-end browser authoring surface for Skillforge
+- exercises the existing draft lifecycle API in a second client surface beyond the CLI
+- advances the project brief toward add/update/delete/list/search support in both CLI and web UI
+- keeps scope aligned with the current draft API instead of reopening architecture work

--- a/openspec/changes/2026-03-29-web-ui-draft-write-slice/specs/web-ui-draft-write-slice/spec.md
+++ b/openspec/changes/2026-03-29-web-ui-draft-write-slice/specs/web-ui-draft-write-slice/spec.md
@@ -1,0 +1,46 @@
+## ADDED Requirements
+
+### Requirement: Provide a browser draft authoring flow
+The Skillforge web UI SHALL support creating browser-driven drafts against the existing draft lifecycle API.
+
+#### Scenario: Create a draft from the web UI
+- **WHEN** a user fills the draft form and submits it from the web UI
+- **THEN** the UI calls `POST /api/v1/drafts`
+- **AND** shows the created draft metadata, validation result, and submission capability
+
+### Requirement: Support multiple draft operations in the web UI
+The first write-capable UI slice SHALL support create, update, and delete draft operations.
+
+#### Scenario: Create or update draft with content
+- **WHEN** a user chooses `create` or `update`
+- **THEN** the UI includes draft content in the create request
+
+#### Scenario: Create delete draft without content
+- **WHEN** a user chooses `delete`
+- **THEN** the UI creates the draft without requiring content
+- **AND** clearly communicates that the delete operation removes the current skill from the draft workspace
+
+### Requirement: Surface draft submission readiness honestly
+The write-capable web UI SHALL expose whether the created draft can be submitted and why not when submission is unavailable.
+
+#### Scenario: Draft submission is unavailable
+- **WHEN** the draft create or status response reports `submission.enabled = false`
+- **THEN** the UI shows that submission is unavailable
+- **AND** includes the reported reason when one exists
+
+#### Scenario: Submit the current draft from the web UI
+- **WHEN** a user submits a created draft from the web UI
+- **THEN** the UI calls `POST /api/v1/drafts/{id}/submit`
+- **AND** shows the returned branch/base-branch metadata and pull request information when available
+
+### Requirement: Show explicit write-path failures
+The write-capable web UI SHALL surface create and submit failures instead of silently failing.
+
+#### Scenario: Draft creation fails
+- **WHEN** draft creation returns a non-success response
+- **THEN** the UI shows an explicit draft creation error state
+
+#### Scenario: Draft submission fails
+- **WHEN** draft submission returns a non-success response
+- **THEN** the UI shows an explicit draft submission error state
+- **AND** preserves any returned validation or submission status details when available

--- a/openspec/changes/2026-03-29-web-ui-draft-write-slice/tasks.md
+++ b/openspec/changes/2026-03-29-web-ui-draft-write-slice/tasks.md
@@ -1,0 +1,24 @@
+# Tasks: web-ui-draft-write-slice
+
+## 1. OpenSpec
+
+- [x] 1.1 Write proposal/design/tasks for the first write-capable web UI slice.
+- [x] 1.2 Add spec deltas for browser draft create/status/submit behavior.
+
+## 2. Frontend draft API layer
+
+- [x] 2.1 Extend `web/src/api.ts` with typed draft create/status/submit helpers.
+
+## 3. First write UI batch
+
+- [x] 3.1 Add a draft authoring panel to the existing web UI.
+- [x] 3.2 Support create, update, and delete draft operations from the browser.
+- [x] 3.3 Surface validation findings and submission capability/status after draft creation.
+- [x] 3.4 Allow submitting the current created draft from the browser.
+- [x] 3.5 Add targeted UI tests for representative create/submit states.
+
+## 4. Docs and verification
+
+- [x] 4.1 Update web/local-development docs for the write-capable UI slice.
+- [x] 4.2 Validate the frontend and OpenSpec change strictly.
+- [x] 4.3 Open or update the round-5 PR with this first implementation batch.

--- a/web/README.md
+++ b/web/README.md
@@ -1,6 +1,6 @@
 # Skillforge web UI
 
-This package contains the first read-only browser UI for Skillforge.
+This package contains the current browser UI for Skillforge.
 
 ## Scope of this slice
 
@@ -11,9 +11,12 @@ The current UI supports:
 - full-text search
 - skill detail viewing
 - URL-backed `?q=` search and `?skill=` selection for shareable deep links
+- browser draft creation for `create`, `update`, and `delete` operations
+- draft validation and submission-capability/status display
+- browser submission of the current draft through the existing draft API
 - basic loading, empty, and error states
 
-It intentionally does **not** include draft authoring or submission yet.
+It still does **not** include multi-draft history, reviewer/admin dashboards, or auth/user management.
 
 ## Local development
 

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -18,7 +18,9 @@ body {
 }
 
 button,
-input {
+input,
+select,
+textarea {
   font: inherit;
 }
 
@@ -120,6 +122,12 @@ button:hover {
   filter: brightness(1.05);
 }
 
+button:disabled {
+  cursor: not-allowed;
+  opacity: 0.65;
+  filter: none;
+}
+
 .button-secondary {
   background: rgba(148, 163, 184, 0.18);
 }
@@ -131,6 +139,10 @@ button:hover {
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
+}
+
+.section-block + .section-block {
+  margin-top: 1.5rem;
 }
 
 .skill-list-item {
@@ -209,6 +221,59 @@ button:hover {
   border: 1px solid rgba(148, 163, 184, 0.18);
   overflow-x: auto;
   white-space: pre-wrap;
+}
+
+.inline-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin: 1rem 0;
+}
+
+.draft-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.draft-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+}
+
+.draft-form label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  font-weight: 700;
+}
+
+.draft-form input,
+.draft-form select,
+.draft-form textarea {
+  width: 100%;
+  background: #0b1020;
+  color: #f8fbff;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  border-radius: 12px;
+  padding: 0.85rem 1rem;
+}
+
+.draft-form textarea {
+  resize: vertical;
+  min-height: 240px;
+}
+
+.draft-result,
+.submission-result {
+  margin-top: 1.5rem;
+  padding-top: 1.25rem;
+  border-top: 1px solid rgba(148, 163, 184, 0.14);
+}
+
+a {
+  color: #8fb7ff;
 }
 
 @media (max-width: 900px) {

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react'
+import { fireEvent, render, screen, within } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import App from './App'
 
@@ -290,6 +290,85 @@ describe('App', () => {
 
     expect(await screen.findByText('draft-delete-01')).toBeInTheDocument()
     expect(await screen.findByText(/Submission is disabled\. submission backend is not configured/)).toBeInTheDocument()
+  })
+
+  it('surfaces backend validation and submission details after a failed submit attempt', async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = parseUrl(input)
+      if (url.pathname === '/api/v1/index/status') {
+        return response({ ready: true, source: 'git', scannedAt: '2026-03-28T21:00:00Z', skillCount: 1 })
+      }
+      if (url.pathname === '/api/v1/skills') {
+        return response({
+          skills: [{ name: 'git-pr-review', description: 'Review PRs', path: 'skills/git-pr-review/SKILL.md', valid: true }],
+          total: 1,
+          offset: 0,
+          limit: 200,
+        })
+      }
+      if (url.pathname === '/api/v1/skills/git-pr-review') {
+        return response({
+          name: 'git-pr-review',
+          description: 'Review PRs',
+          path: 'skills/git-pr-review/SKILL.md',
+          body: '---\nname: git-pr-review\ndescription: Review PRs\n---\n# git-pr-review\n',
+          valid: true,
+        })
+      }
+      if (url.pathname === '/api/v1/drafts') {
+        expect(parseJsonBody(init)).toEqual({
+          operation: 'update',
+          skillName: 'git-pr-review',
+          content: '---\nname: git-pr-review\ndescription: Review PRs\n---\n# git-pr-review\n',
+        })
+        return response({
+          id: 'draft-submit-error',
+          operation: 'update',
+          skillName: 'git-pr-review',
+          branchName: 'skillforge/update/git-pr-review/draft-submit-error',
+          createdAt: '2026-03-29T06:00:00Z',
+          validation: { valid: true },
+          submission: { enabled: true, baseBranch: 'main' },
+        })
+      }
+      if (url.pathname === '/api/v1/drafts/draft-submit-error/submit') {
+        return response(
+          {
+            error: 'submission_failed',
+            message: 'remote rejected the branch update',
+            validation: {
+              valid: false,
+              findings: [{ code: 'frontmatter', message: 'description is missing', path: 'description' }],
+            },
+            submission: {
+              enabled: false,
+              baseBranch: 'main',
+              reason: 'fix validation findings before retrying submission',
+            },
+          },
+          409,
+        )
+      }
+      throw new Error(`unexpected URL ${url}`)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<App />)
+
+    expect(await screen.findByText('Body preview')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Prefill update from selected skill' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Create draft' }))
+    expect(await screen.findByText('draft-submit-error')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Submit draft' }))
+
+    const failureSection = await screen.findByLabelText('submit failure details')
+    expect(within(failureSection).getByText('Could not submit draft: remote rejected the branch update')).toBeInTheDocument()
+    expect(within(failureSection).getByText('Latest backend status after failed submit')).toBeInTheDocument()
+    expect(within(failureSection).getByText(/Submission is disabled\. Base branch: main\. fix validation findings before retrying submission/)).toBeInTheDocument()
+    expect(within(failureSection).getByText('Validation still reports findings on the draft.')).toBeInTheDocument()
+    expect(within(failureSection).getByText('frontmatter')).toBeInTheDocument()
+    expect(failureSection).toHaveTextContent('description is missing')
   })
 
   it('shows a draft creation error when the write request fails', async () => {

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import App from './App'
 
@@ -48,6 +48,7 @@ describe('App', () => {
     expect(await screen.findByText('git-pr-review')).toBeInTheDocument()
     expect(await screen.findByText('Use gh pr review.')).toBeInTheDocument()
     expect(await screen.findByText('2 indexed skill(s)')).toBeInTheDocument()
+    expect(await screen.findByText('Create a browser draft')).toBeInTheDocument()
   })
 
   it('hydrates search and selected skill from the URL', async () => {
@@ -162,19 +163,16 @@ describe('App', () => {
     expect(fetchMock).toHaveBeenCalledWith(expect.stringContaining('/api/v1/skills?offset=200&limit=200'), expect.any(Object))
   })
 
-  it('updates the URL when the selected skill changes', async () => {
-    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+  it('creates and submits a draft from the browser form', async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = parseUrl(input)
       if (url.pathname === '/api/v1/index/status') {
-        return response({ ready: true, source: 'git', scannedAt: '2026-03-28T21:00:00Z', skillCount: 2 })
+        return response({ ready: true, source: 'git', scannedAt: '2026-03-28T21:00:00Z', skillCount: 1 })
       }
       if (url.pathname === '/api/v1/skills') {
         return response({
-          skills: [
-            { name: 'git-pr-review', description: 'Review PRs', path: 'skills/git-pr-review/SKILL.md', valid: true },
-            { name: 'pdf-search-helper', description: 'Find text in PDFs', path: 'skills/pdf-search-helper/SKILL.md', valid: true },
-          ],
-          total: 2,
+          skills: [{ name: 'git-pr-review', description: 'Review PRs', path: 'skills/git-pr-review/SKILL.md', valid: true }],
+          total: 1,
           offset: 0,
           limit: 200,
         })
@@ -184,16 +182,38 @@ describe('App', () => {
           name: 'git-pr-review',
           description: 'Review PRs',
           path: 'skills/git-pr-review/SKILL.md',
+          body: '---\nname: git-pr-review\ndescription: Review PRs\n---\n# git-pr-review\n',
           valid: true,
         })
       }
-      if (url.pathname === '/api/v1/skills/pdf-search-helper') {
+      if (url.pathname === '/api/v1/drafts') {
+        expect(init?.method).toBe('POST')
+        expect(parseJsonBody(init)).toEqual({
+          operation: 'update',
+          skillName: 'git-pr-review',
+          content: '---\nname: git-pr-review\ndescription: Review PRs\n---\n# git-pr-review\n',
+        })
         return response({
-          name: 'pdf-search-helper',
-          description: 'Find text in PDFs',
-          path: 'skills/pdf-search-helper/SKILL.md',
-          body: 'Use pdftotext first.',
-          valid: true,
+          id: 'draft01',
+          operation: 'update',
+          skillName: 'git-pr-review',
+          branchName: 'skillforge/update/git-pr-review/draft01',
+          createdAt: '2026-03-29T05:10:00Z',
+          validation: { valid: true },
+          submission: { enabled: true, baseBranch: 'main' },
+        })
+      }
+      if (url.pathname === '/api/v1/drafts/draft01/submit') {
+        expect(init?.method).toBe('POST')
+        return response({
+          id: 'draft01',
+          operation: 'update',
+          skillName: 'git-pr-review',
+          branchName: 'skillforge/update/git-pr-review/draft01',
+          baseBranch: 'main',
+          commitHash: 'abc123',
+          pullRequest: { number: 17, url: 'https://forgejo.example/pr/17' },
+          validation: { valid: true },
         })
       }
       throw new Error(`unexpected URL ${url}`)
@@ -202,50 +222,87 @@ describe('App', () => {
 
     render(<App />)
 
-    expect(await screen.findByText('git-pr-review')).toBeInTheDocument()
-    fireEvent.click(screen.getByRole('button', { name: /pdf-search-helper/i }))
+    expect(await screen.findByText('Body preview')).toBeInTheDocument()
 
-    await waitFor(() => {
-      const params = new URLSearchParams(window.location.search)
-      expect(params.get('skill')).toBe('pdf-search-helper')
-    })
+    fireEvent.click(screen.getByRole('button', { name: 'Prefill update from selected skill' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Create draft' }))
+
+    expect(await screen.findByText('Current draft')).toBeInTheDocument()
+    expect(await screen.findByText('draft01')).toBeInTheDocument()
+    expect(await screen.findByText('Submission is enabled. Base branch: main.')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Submit draft' }))
+
+    expect(await screen.findByText('Submission result')).toBeInTheDocument()
+    expect(await screen.findByText('abc123')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: '#17' })).toHaveAttribute('href', 'https://forgejo.example/pr/17')
   })
 
-  it('shows an empty search state and syncs the query into the URL', async () => {
+  it('creates delete drafts without sending content', async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = parseUrl(input)
+      if (url.pathname === '/api/v1/index/status') {
+        return response({ ready: true, source: 'git', scannedAt: '2026-03-28T21:00:00Z', skillCount: 1 })
+      }
+      if (url.pathname === '/api/v1/skills') {
+        return response({
+          skills: [{ name: 'git-pr-review', description: 'Review PRs', path: 'skills/git-pr-review/SKILL.md', valid: true }],
+          total: 1,
+          offset: 0,
+          limit: 200,
+        })
+      }
+      if (url.pathname === '/api/v1/skills/git-pr-review') {
+        return response({
+          name: 'git-pr-review',
+          description: 'Review PRs',
+          path: 'skills/git-pr-review/SKILL.md',
+          body: 'Use gh pr review.',
+          valid: true,
+        })
+      }
+      if (url.pathname === '/api/v1/drafts') {
+        expect(parseJsonBody(init)).toEqual({
+          operation: 'delete',
+          skillName: 'git-pr-review',
+        })
+        return response({
+          id: 'draft-delete-01',
+          operation: 'delete',
+          skillName: 'git-pr-review',
+          branchName: 'skillforge/delete/git-pr-review/draft-delete-01',
+          createdAt: '2026-03-29T05:20:00Z',
+          validation: { valid: true },
+          submission: { enabled: false, reason: 'submission backend is not configured' },
+        })
+      }
+      throw new Error(`unexpected URL ${url}`)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<App />)
+
+    expect(await screen.findByText('Use gh pr review.')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Prepare delete for selected skill' }))
+
+    expect(screen.queryByLabelText('Draft content')).not.toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Create draft' }))
+
+    expect(await screen.findByText('draft-delete-01')).toBeInTheDocument()
+    expect(await screen.findByText(/Submission is disabled\. submission backend is not configured/)).toBeInTheDocument()
+  })
+
+  it('shows a draft creation error when the write request fails', async () => {
     const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
       const url = parseUrl(input)
       if (url.pathname === '/api/v1/index/status') {
         return response({ ready: true, source: 'git', scannedAt: '2026-03-28T21:00:00Z', skillCount: 0 })
-      }
-      if (url.pathname === '/api/v1/search') {
-        expect(url.searchParams.get('q')).toBe('nomatch')
-        return response({ query: 'nomatch', skills: [], total: 0 })
       }
       if (url.pathname === '/api/v1/skills') {
         return response({ skills: [], total: 0, offset: 0, limit: 200 })
       }
-      throw new Error(`unexpected URL ${url}`)
-    })
-    vi.stubGlobal('fetch', fetchMock)
-
-    render(<App />)
-
-    const input = await screen.findByLabelText('Search skills')
-    fireEvent.change(input, { target: { value: 'nomatch' } })
-    fireEvent.click(screen.getByText('Search'))
-
-    expect(await screen.findByText('No skills matched this query.')).toBeInTheDocument()
-    expect(new URLSearchParams(window.location.search).get('q')).toBe('nomatch')
-  })
-
-  it('shows a loading error when the catalog request fails', async () => {
-    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
-      const url = parseUrl(input)
-      if (url.pathname === '/api/v1/index/status') {
-        return response({ ready: true, source: 'git', scannedAt: '2026-03-28T21:00:00Z', skillCount: 0 })
-      }
-      if (url.pathname === '/api/v1/skills') {
-        return response({ error: 'unavailable', message: 'catalog unavailable' }, 503)
+      if (url.pathname === '/api/v1/drafts') {
+        return response({ error: 'invalid_request', message: 'content is required for create' }, 400)
       }
       throw new Error(`unexpected URL ${url}`)
     })
@@ -253,12 +310,25 @@ describe('App', () => {
 
     render(<App />)
 
-    expect(await screen.findByText('Could not load skills: catalog unavailable')).toBeInTheDocument()
+    const skillInput = await screen.findByLabelText('Skill name')
+    fireEvent.change(skillInput, { target: { value: 'new-skill' } })
+    fireEvent.change(screen.getByLabelText('Draft content'), { target: { value: '' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Create draft' }))
+
+    expect(await screen.findByText('Could not create draft: content is required for create')).toBeInTheDocument()
   })
 })
 
 function parseUrl(input: RequestInfo | URL): URL {
   return new URL(String(input), 'http://localhost')
+}
+
+function parseJsonBody(init?: RequestInit): unknown {
+  const body = init?.body
+  if (typeof body !== 'string') {
+    throw new Error(`expected JSON string body, got ${typeof body}`)
+  }
+  return JSON.parse(body)
 }
 
 function response(payload: unknown, status = 200): Response {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -506,7 +506,36 @@ function App() {
               </section>
             ) : null}
 
-            {submitState === 'error' ? <p className="state-message error">Could not submit draft: {submitError}</p> : null}
+            {submitState === 'error' ? (
+              <section className="submission-result" aria-label="submit failure details">
+                <p className="state-message error">Could not submit draft: {submitError}</p>
+                {currentDraft ? (
+                  <>
+                    <h3>Latest backend status after failed submit</h3>
+                    <p className="state-message">
+                      Submission is {currentDraft.submission.enabled ? 'enabled' : 'disabled'}.
+                      {currentDraft.submission.baseBranch ? ` Base branch: ${currentDraft.submission.baseBranch}.` : ''}
+                      {currentDraft.submission.reason ? ` ${currentDraft.submission.reason}` : ''}
+                    </p>
+                    <p className="state-message">
+                      {currentDraft.validation.valid
+                        ? 'Validation still reports the draft as valid.'
+                        : 'Validation still reports findings on the draft.'}
+                    </p>
+                    {currentDraft.validation.findings && currentDraft.validation.findings.length > 0 ? (
+                      <ul className="findings-list">
+                        {currentDraft.validation.findings.map((finding) => (
+                          <li key={`${finding.code}-${finding.path ?? finding.message}`}>
+                            <strong>{finding.code}</strong>: {finding.message}
+                            {finding.path ? <span className="muted"> ({finding.path})</span> : null}
+                          </li>
+                        ))}
+                      </ul>
+                    ) : null}
+                  </>
+                ) : null}
+              </section>
+            ) : null}
 
             {submissionResult ? (
               <section className="submission-result" aria-label="submission result">

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,13 +1,36 @@
 import { useEffect, useMemo, useState, type FormEvent } from 'react'
 import './App.css'
-import { getIndexStatus, getSkill, listAllSkills, searchSkills, type IndexStatus, type SkillRecord } from './api'
+import {
+  ApiRequestError,
+  createDraft,
+  getDraft,
+  getIndexStatus,
+  getSkill,
+  listAllSkills,
+  searchSkills,
+  submitDraft,
+  type DraftOperation,
+  type DraftResponse,
+  type DraftSubmissionResponse,
+  type IndexStatus,
+  type SkillRecord,
+} from './api'
 
 type LoadState = 'idle' | 'loading' | 'ready' | 'error'
+type DraftState = 'idle' | 'creating' | 'refreshing' | 'ready' | 'error'
+type SubmitState = 'idle' | 'submitting' | 'ready' | 'error'
 
 type UiLocationState = {
   query: string
   skill: string
 }
+
+const defaultDraftContent = `---
+name: new-skill
+description: Describe the skill
+---
+# new-skill
+`
 
 function App() {
   const initialLocationState = readLocationState()
@@ -21,6 +44,16 @@ function App() {
   const [detailState, setDetailState] = useState<LoadState>('idle')
   const [detailError, setDetailError] = useState('')
   const [indexStatus, setIndexStatus] = useState<IndexStatus | null>(null)
+
+  const [draftOperation, setDraftOperation] = useState<DraftOperation>('create')
+  const [draftSkillName, setDraftSkillName] = useState('')
+  const [draftContent, setDraftContent] = useState(defaultDraftContent)
+  const [draftState, setDraftState] = useState<DraftState>('idle')
+  const [draftError, setDraftError] = useState('')
+  const [currentDraft, setCurrentDraft] = useState<DraftResponse | null>(null)
+  const [submitState, setSubmitState] = useState<SubmitState>('idle')
+  const [submitError, setSubmitError] = useState('')
+  const [submissionResult, setSubmissionResult] = useState<DraftSubmissionResponse | null>(null)
 
   useEffect(() => {
     syncLocationState({ query: submittedQuery, skill: selectedSkillName })
@@ -121,6 +154,9 @@ function App() {
     return `${indexStatus.skillCount} indexed skill(s)`
   }, [indexStatus])
 
+  const createButtonLabel = draftState === 'creating' ? 'Creating draft…' : 'Create draft'
+  const submitButtonLabel = submitState === 'submitting' ? 'Submitting…' : 'Submit draft'
+
   const onSearch = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault()
     setSubmittedQuery(query.trim())
@@ -132,13 +168,100 @@ function App() {
     setSelectedSkillName('')
   }
 
+  const onCreateDraft = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    setDraftState('creating')
+    setDraftError('')
+    setSubmitState('idle')
+    setSubmitError('')
+    setSubmissionResult(null)
+
+    try {
+      const created = await createDraft({
+        operation: draftOperation,
+        skillName: draftSkillName.trim(),
+        ...(draftOperation === 'delete' ? {} : { content: draftContent }),
+      })
+      setCurrentDraft(created)
+      setDraftState('ready')
+    } catch (error) {
+      setCurrentDraft(null)
+      setDraftState('error')
+      setDraftError(error instanceof Error ? error.message : 'request failed')
+    }
+  }
+
+  const onRefreshDraft = async () => {
+    if (!currentDraft) {
+      return
+    }
+
+    setDraftState('refreshing')
+    setDraftError('')
+    try {
+      const refreshed = await getDraft(currentDraft.id)
+      setCurrentDraft(refreshed)
+      setDraftState('ready')
+    } catch (error) {
+      setDraftState('error')
+      setDraftError(error instanceof Error ? error.message : 'request failed')
+    }
+  }
+
+  const onSubmitDraft = async () => {
+    if (!currentDraft) {
+      return
+    }
+
+    setSubmitState('submitting')
+    setSubmitError('')
+    try {
+      const result = await submitDraft(currentDraft.id)
+      setSubmissionResult(result)
+      setSubmitState('ready')
+    } catch (error) {
+      if (error instanceof ApiRequestError) {
+        setCurrentDraft((previous) => {
+          if (!previous) {
+            return previous
+          }
+          return {
+            ...previous,
+            validation: error.validation ?? previous.validation,
+            submission: error.submission ?? previous.submission,
+          }
+        })
+      }
+      setSubmissionResult(null)
+      setSubmitState('error')
+      setSubmitError(error instanceof Error ? error.message : 'request failed')
+    }
+  }
+
+  const onPrefillFromSelection = () => {
+    if (!selectedSkill) {
+      return
+    }
+    setDraftOperation('update')
+    setDraftSkillName(selectedSkill.name)
+    setDraftContent(selectedSkill.body ?? '')
+  }
+
+  const onPrepareDeleteFromSelection = () => {
+    if (!selectedSkill) {
+      return
+    }
+    setDraftOperation('delete')
+    setDraftSkillName(selectedSkill.name)
+  }
+
   return (
     <div className="app-shell">
       <header className="topbar">
         <div>
           <p className="eyebrow">Skillforge</p>
-          <h1>Browse skills</h1>
-          <p className="subtitle">Read-only web UI for catalog discovery on top of the current Go API.</p>
+          <h1>Browse and draft skills</h1>
+          <p className="subtitle">Read the catalog, then create and submit draft mutations through the current Go API.</p>
         </div>
         <div className="status-card" aria-label="index status">
           <span className="status-label">Catalog status</span>
@@ -197,7 +320,7 @@ function App() {
           {detailState === 'error' ? <p className="state-message error">Could not load skill details: {detailError}</p> : null}
 
           {detailState === 'ready' && selectedSkill ? (
-            <article className="detail-card">
+            <article className="detail-card section-block">
               <div className="detail-header">
                 <div>
                   <p className="eyebrow">Skill detail</p>
@@ -245,6 +368,180 @@ function App() {
               ) : null}
             </article>
           ) : null}
+
+          <article className="draft-card section-block">
+            <div className="detail-header">
+              <div>
+                <p className="eyebrow">Draft authoring</p>
+                <h2>Create a browser draft</h2>
+              </div>
+              {currentDraft ? (
+                <span className={currentDraft.validation.valid ? 'pill valid' : 'pill invalid'}>
+                  {currentDraft.validation.valid ? 'draft valid' : 'draft invalid'}
+                </span>
+              ) : null}
+            </div>
+
+            <p className="muted">
+              This first write slice creates a draft workspace through the existing draft API, shows validation/submission status,
+              and can submit the current draft when the backend allows it.
+            </p>
+
+            {selectedSkill ? (
+              <div className="inline-actions">
+                <button type="button" className="button-secondary" onClick={onPrefillFromSelection}>
+                  Prefill update from selected skill
+                </button>
+                <button type="button" className="button-secondary" onClick={onPrepareDeleteFromSelection}>
+                  Prepare delete for selected skill
+                </button>
+              </div>
+            ) : null}
+
+            <form className="draft-form" onSubmit={onCreateDraft}>
+              <div className="draft-grid">
+                <label>
+                  Operation
+                  <select value={draftOperation} onChange={(event) => setDraftOperation(event.target.value as DraftOperation)}>
+                    <option value="create">create</option>
+                    <option value="update">update</option>
+                    <option value="delete">delete</option>
+                  </select>
+                </label>
+                <label>
+                  Skill name
+                  <input
+                    value={draftSkillName}
+                    onChange={(event) => setDraftSkillName(event.target.value)}
+                    placeholder="example-skill"
+                  />
+                </label>
+              </div>
+
+              {draftOperation !== 'delete' ? (
+                <label>
+                  Draft content
+                  <textarea
+                    value={draftContent}
+                    onChange={(event) => setDraftContent(event.target.value)}
+                    placeholder="---\nname: example-skill\ndescription: ...\n---\n# example-skill"
+                    rows={12}
+                  />
+                </label>
+              ) : (
+                <p className="state-message">Delete drafts reuse the current skill path and do not require draft content.</p>
+              )}
+
+              <div className="inline-actions">
+                <button type="submit" disabled={draftState === 'creating'}>
+                  {createButtonLabel}
+                </button>
+                <button type="button" className="button-secondary" onClick={onRefreshDraft} disabled={!currentDraft || draftState === 'refreshing'}>
+                  {draftState === 'refreshing' ? 'Refreshing…' : 'Refresh current draft'}
+                </button>
+              </div>
+            </form>
+
+            {draftState === 'error' ? <p className="state-message error">Could not create draft: {draftError}</p> : null}
+
+            {currentDraft ? (
+              <section className="draft-result" aria-label="current draft">
+                <h3>Current draft</h3>
+                <dl className="meta-grid">
+                  <div>
+                    <dt>Draft ID</dt>
+                    <dd>{currentDraft.id}</dd>
+                  </div>
+                  <div>
+                    <dt>Operation</dt>
+                    <dd>{currentDraft.operation}</dd>
+                  </div>
+                  <div>
+                    <dt>Skill</dt>
+                    <dd>{currentDraft.skillName}</dd>
+                  </div>
+                  <div>
+                    <dt>Branch</dt>
+                    <dd>{currentDraft.branchName}</dd>
+                  </div>
+                  <div>
+                    <dt>Created</dt>
+                    <dd>{formatTimestamp(currentDraft.createdAt)}</dd>
+                  </div>
+                  <div>
+                    <dt>Submission</dt>
+                    <dd>{currentDraft.submission.enabled ? 'enabled' : 'disabled'}</dd>
+                  </div>
+                </dl>
+
+                <section>
+                  <h3>Validation status</h3>
+                  <p className="state-message">{currentDraft.validation.valid ? 'Draft validation passed.' : 'Draft validation reported findings.'}</p>
+                  {currentDraft.validation.findings && currentDraft.validation.findings.length > 0 ? (
+                    <ul className="findings-list">
+                      {currentDraft.validation.findings.map((finding) => (
+                        <li key={`${finding.code}-${finding.path ?? finding.message}`}>
+                          <strong>{finding.code}</strong>: {finding.message}
+                          {finding.path ? <span className="muted"> ({finding.path})</span> : null}
+                        </li>
+                      ))}
+                    </ul>
+                  ) : null}
+                </section>
+
+                <section>
+                  <h3>Submission status</h3>
+                  <p className="state-message">
+                    Submission is {currentDraft.submission.enabled ? 'enabled' : 'disabled'}.
+                    {currentDraft.submission.baseBranch ? ` Base branch: ${currentDraft.submission.baseBranch}.` : ''}
+                    {currentDraft.submission.reason ? ` ${currentDraft.submission.reason}` : ''}
+                  </p>
+                </section>
+
+                <div className="inline-actions">
+                  <button type="button" onClick={onSubmitDraft} disabled={!currentDraft.submission.enabled || submitState === 'submitting'}>
+                    {submitButtonLabel}
+                  </button>
+                </div>
+              </section>
+            ) : null}
+
+            {submitState === 'error' ? <p className="state-message error">Could not submit draft: {submitError}</p> : null}
+
+            {submissionResult ? (
+              <section className="submission-result" aria-label="submission result">
+                <h3>Submission result</h3>
+                <dl className="meta-grid">
+                  <div>
+                    <dt>Branch</dt>
+                    <dd>{submissionResult.branchName}</dd>
+                  </div>
+                  <div>
+                    <dt>Base branch</dt>
+                    <dd>{submissionResult.baseBranch}</dd>
+                  </div>
+                  <div>
+                    <dt>Commit</dt>
+                    <dd>{submissionResult.commitHash ?? 'Not reported'}</dd>
+                  </div>
+                  <div>
+                    <dt>Pull request</dt>
+                    <dd>
+                      {submissionResult.pullRequest?.url ? (
+                        <a href={submissionResult.pullRequest.url} target="_blank" rel="noreferrer">
+                          {submissionResult.pullRequest.number ? `#${submissionResult.pullRequest.number}` : submissionResult.pullRequest.url}
+                        </a>
+                      ) : submissionResult.pullRequest?.number ? (
+                        `#${submissionResult.pullRequest.number}`
+                      ) : (
+                        'Not reported'
+                      )}
+                    </dd>
+                  </div>
+                </dl>
+              </section>
+            ) : null}
+          </article>
         </section>
       </main>
     </div>
@@ -277,6 +574,19 @@ function syncLocationState(state: UiLocationState): void {
   const search = params.toString()
   const nextUrl = search === '' ? window.location.pathname : `${window.location.pathname}?${search}`
   window.history.replaceState({}, '', nextUrl)
+}
+
+function formatTimestamp(value: string): string {
+  if (!value) {
+    return 'Unknown'
+  }
+
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) {
+    return value
+  }
+
+  return date.toISOString()
 }
 
 export default App

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -39,9 +39,71 @@ export interface IndexStatus {
   }
 }
 
+export type DraftOperation = 'create' | 'update' | 'delete'
+
+export interface DraftValidation {
+  valid: boolean
+  findings?: ValidationFinding[]
+}
+
+export interface DraftSubmissionStatus {
+  enabled: boolean
+  baseBranch?: string
+  reason?: string
+}
+
+export interface DraftCreateRequest {
+  operation: DraftOperation
+  skillName: string
+  content?: string
+}
+
+export interface DraftResponse {
+  id: string
+  operation: DraftOperation
+  skillName: string
+  branchName: string
+  createdAt: string
+  validation: DraftValidation
+  submission: DraftSubmissionStatus
+}
+
+export interface PullRequestRef {
+  number?: number
+  id?: number
+  url?: string
+}
+
+export interface DraftSubmissionResponse {
+  id: string
+  operation: DraftOperation
+  skillName: string
+  branchName: string
+  baseBranch: string
+  commitHash?: string
+  pullRequest?: PullRequestRef
+  validation: DraftValidation
+}
+
 export interface ApiErrorPayload {
   error?: string
   message?: string
+  validation?: DraftValidation
+  submission?: DraftSubmissionStatus
+}
+
+export class ApiRequestError extends Error {
+  code?: string
+  validation?: DraftValidation
+  submission?: DraftSubmissionStatus
+
+  constructor(payload: ApiErrorPayload, status: number) {
+    super(payload.message ?? `request failed with status ${status}`)
+    this.name = 'ApiRequestError'
+    this.code = payload.error
+    this.validation = payload.validation
+    this.submission = payload.submission
+  }
 }
 
 const configuredBase = (import.meta.env.VITE_API_BASE_URL ?? '').trim()
@@ -61,11 +123,14 @@ function buildUrl(path: string, query?: URLSearchParams): string {
   return query && query.size > 0 ? `${url}?${query.toString()}` : url
 }
 
-async function getJson<T>(path: string, query?: URLSearchParams): Promise<T> {
+async function sendJson<T>(method: string, path: string, body?: unknown, query?: URLSearchParams): Promise<T> {
   const response = await fetch(buildUrl(path, query), {
+    method,
     headers: {
       Accept: 'application/json',
+      ...(body !== undefined ? { 'Content-Type': 'application/json' } : {}),
     },
+    body: body !== undefined ? JSON.stringify(body) : undefined,
   })
 
   if (!response.ok) {
@@ -75,10 +140,18 @@ async function getJson<T>(path: string, query?: URLSearchParams): Promise<T> {
     } catch {
       payload = undefined
     }
-    throw new Error(payload?.message ?? `request failed with status ${response.status}`)
+    throw new ApiRequestError(payload ?? {}, response.status)
   }
 
   return (await response.json()) as T
+}
+
+async function getJson<T>(path: string, query?: URLSearchParams): Promise<T> {
+  return sendJson<T>('GET', path, undefined, query)
+}
+
+async function postJson<T>(path: string, body?: unknown): Promise<T> {
+  return sendJson<T>('POST', path, body)
 }
 
 export function listSkills(offset = 0, limit = catalogPageSize): Promise<ListSkillsResponse> {
@@ -128,4 +201,17 @@ export function getSkill(name: string): Promise<SkillRecord> {
 
 export function getIndexStatus(): Promise<IndexStatus> {
   return getJson<IndexStatus>('/api/v1/index/status')
+}
+
+export function createDraft(request: DraftCreateRequest): Promise<DraftResponse> {
+  const payload = request.operation === 'delete' ? { operation: request.operation, skillName: request.skillName } : request
+  return postJson<DraftResponse>('/api/v1/drafts', payload)
+}
+
+export function getDraft(id: string): Promise<DraftResponse> {
+  return getJson<DraftResponse>(`/api/v1/drafts/${encodeURIComponent(id)}`)
+}
+
+export function submitDraft(id: string): Promise<DraftSubmissionResponse> {
+  return postJson<DraftSubmissionResponse>(`/api/v1/drafts/${encodeURIComponent(id)}/submit`)
 }


### PR DESCRIPTION
## Summary
- add the round-5 OpenSpec change for the first write-capable web UI slice
- extend the web app with browser draft create/status/submit flows for create/update/delete operations
- document the write-capable UI and cover representative draft flows in frontend tests

## Verification
- cd web && npm test
- cd web && npm run build
- cd web && npm run lint
- openspec validate 2026-03-29-web-ui-draft-write-slice --strict