### PR TITLE
docs: add review findings and drafted GitHub issues

### DIFF
--- a/reviews/github-issues-2026-04-02/README.md
+++ b/reviews/github-issues-2026-04-02/README.md
@@ -1,0 +1,10 @@
+# Main branch review findings (2026-04-02)
+
+This folder contains GitHub issue drafts generated from a code review pass over the current branch snapshot (used as the available mainline code in this environment).
+
+## Draft issues
+1. `issue-01-draft-create-allows-trailing-json.md`
+2. `issue-02-workspace-copy-follows-symlinks.md`
+
+## Note
+Direct issue creation was not executed in this environment because the GitHub CLI is not installed and no repository remote/auth context is configured.

--- a/reviews/github-issues-2026-04-02/issue-01-draft-create-allows-trailing-json.md
+++ b/reviews/github-issues-2026-04-02/issue-01-draft-create-allows-trailing-json.md
@@ -1,0 +1,52 @@
+# Title
+`POST /api/v1/drafts` accepts trailing JSON payloads after the first object
+
+# Type
+Bug
+
+# Severity
+Medium
+
+# Summary
+The request decoder in `decodeDraftCreateRequest` only performs a single `Decode` call and does not verify end-of-input. This allows extra trailing tokens (including a second JSON object) to be silently ignored.
+
+# Impact
+- Client/server parsing can become ambiguous when intermediaries or client libraries treat the trailing bytes differently.
+- Attackers can hide unexpected payloads in logs and audit streams while still getting a successful response for the first object.
+- API behavior is inconsistent with strict JSON request contracts expected by many clients.
+
+# Evidence
+`decodeDraftCreateRequest` uses:
+
+```go
+dec := json.NewDecoder(r.Body)
+dec.DisallowUnknownFields()
+if err := dec.Decode(&req); err != nil {
+    return draftCreateRequest{}, fmt.Errorf("decode request body: %w", err)
+}
+return req, nil
+```
+
+There is no second decode / EOF check.
+
+# Reproduction
+```bash
+curl -i -X POST http://localhost:8080/api/v1/drafts \
+  -H 'content-type: application/json' \
+  --data '{"operation":"create","skillName":"demo-skill","content":"# Skill"}{"ignored":true}'
+```
+
+Expected: HTTP 400 invalid request.
+Observed: request can be accepted based on the first object.
+
+# Suggested fix
+After the first successful decode, decode once more into `struct{}` and require `io.EOF`:
+
+```go
+if err := dec.Decode(&struct{}{}); err != io.EOF {
+    return draftCreateRequest{}, fmt.Errorf("decode request body: trailing content")
+}
+```
+
+# Affected files
+- `internal/api/drafts.go`

--- a/reviews/github-issues-2026-04-02/issue-02-workspace-copy-follows-symlinks.md
+++ b/reviews/github-issues-2026-04-02/issue-02-workspace-copy-follows-symlinks.md
@@ -1,0 +1,51 @@
+# Title
+Draft workspace copy follows symlinks and can read files outside the repository
+
+# Type
+Security Bug
+
+# Severity
+High
+
+# Summary
+`copyRepoTree` copies repository files by opening each path directly. When the source repository contains symlinks, `os.Open(src)` follows the symlink target. This can copy arbitrary host files into the draft workspace if a symlink points outside the repo.
+
+# Impact
+- Sensitive host data may be read into a draft workspace unexpectedly.
+- Subsequent submit/publish flow could commit leaked data into branches/PRs.
+- In multi-tenant/self-hosted scenarios this becomes a data exfiltration risk.
+
+# Evidence
+The copy flow:
+
+```go
+return filepath.WalkDir(src, func(path string, d fs.DirEntry, err error) error {
+    ...
+    info, err := d.Info()
+    ...
+    return copyFile(path, target, info.Mode())
+})
+```
+
+`copyFile` then does:
+
+```go
+in, err := os.Open(src)
+...
+io.Copy(out, in)
+```
+
+No symlink filtering is present.
+
+# Reproduction
+1. Add a symlink in the canonical repo: `ln -s /etc/hosts skills/leak/SKILL.md`
+2. Trigger draft workspace creation.
+3. Observe the resulting workspace file contains `/etc/hosts` content, not symlink metadata.
+
+# Suggested fix
+- During tree walk, detect and reject symlinks (`d.Type()&fs.ModeSymlink != 0`) or preserve symlinks without dereferencing.
+- Enforce that all copied paths resolve within the repo root before opening.
+- Add a regression test with an external symlink target.
+
+# Affected files
+- `internal/draft/manager.go`


### PR DESCRIPTION
### Motivation
- Performed a review pass over the current mainline code snapshot to capture actionable defects and security concerns discovered in the API and draft workspace code. 
- Prepared reproducible, review-ready GitHub issue drafts to make findings easy to file and track in the repository.

### Description
- Added a new folder `reviews/github-issues-2026-04-02/` containing a `README.md` index and two issue drafts describing the findings. 
- Included `issue-01-draft-create-allows-trailing-json.md` documenting a bug where `decodeDraftCreateRequest` does not enforce EOF after JSON decoding. 
- Included `issue-02-workspace-copy-follows-symlinks.md` documenting a high-severity symlink handling/security issue in the draft workspace copy logic (`copyRepoTree` / `copyFile`). 
- Drafts were recorded as markdown files in-repo because the environment lacks a configured remote and the GitHub CLI (`gh`) is not available for live issue creation. 

### Testing
- Ran `go test ./...` and all Go tests passed. 
- Ran `cd web && npm test -- --run` and the web test suite passed. 
- Ran `cd web && npm run lint` and the linter completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cdddf2a6c4832189802ba104c3a5f2)